### PR TITLE
improve GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,26 +2,29 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---
 
-**Describe the bug**
+## Description
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## To reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+## Expected behaviour
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+## Screenshots
 If applicable, add screenshots to help explain your problem.
+
+## Platform
+Choose from one of the below:
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]
@@ -34,5 +37,5 @@ If applicable, add screenshots to help explain your problem.
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
-**Additional context**
+## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Description of problem
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Proposed solution
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Alternatives considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,8 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+projects: 'PockyBot'
+labels: 'enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,6 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-projects: 'PockyBot'
 labels: 'enhancement'
 assignees: ''
 


### PR DESCRIPTION
Might also want to have these auto-add the "PockyBot" project, but I'm not sure if or how to do that, and if it is, if or how you can have it auto assign to, e.g. "Bugfixes/Maintenance in PockyBot".